### PR TITLE
Fixed OfferCard buttons & CreateOffer input errors

### DIFF
--- a/src/components/CreateOffer.js
+++ b/src/components/CreateOffer.js
@@ -40,9 +40,9 @@ function CreateOffer(props) {
     // Offer data
     const [currentOfferCoordinates, setCurrentOfferCoordinates] = useState([]);
 
-    const [landXValue, setLandXValue] = useState("");
-    const [landYValue, setLandYValue] = useState("");
-    const [rmrkPrice, setRMRKPrice] = useState("");
+    const [landXValue, setLandXValue] = useState(NaN);
+    const [landYValue, setLandYValue] = useState(NaN);
+    const [rmrkPrice, setRMRKPrice] = useState(NaN);
 
     // Interface animation state
     const [isExpanded, setIsExpanded] = useState(true);
@@ -386,7 +386,7 @@ function CreateOffer(props) {
                                             onChange={handleXChange}
                                             value={landXValue}
                                             placeholder="X"
-                                            sx={{ maxWidth: 1000 }}
+                                            sx={{ maxWidth: 100 }}
                                         />
                                     </Grid>
                                     <Grid item xs='auto'>
@@ -400,7 +400,7 @@ function CreateOffer(props) {
                                             onChange={handleYChange}
                                             value={landYValue}
                                             placeholder="Y"
-                                            sx={{ maxWidth: 1000 }}
+                                            sx={{ maxWidth: 100 }}
                                         />
                                     </Grid>
                                     <Grid item xs='auto'>

--- a/src/components/OfferCard.js
+++ b/src/components/OfferCard.js
@@ -9,7 +9,7 @@ import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
-import { Box, IconButton, Button } from '@mui/material';
+import { Box, IconButton, Button, Grid } from '@mui/material';
 import LandListEntry from './minorComponents/LandListEntry';
 
 // Blockchain imports
@@ -163,7 +163,7 @@ function OfferCard(props) {
                         popupType="warning"
                         popupMessage={"Confirm that you want to deposit the "}
                         popupButtonMessage="Confirm declaration"
-                        popupButtonAction={buyLandBlock()} />
+                        popupButtonAction={buyLandBlock} />
                     :
                     <></>
                 }
@@ -174,7 +174,7 @@ function OfferCard(props) {
                         popupType="warning"
                         popupMessage={"Confirm that you want to approve the smart contract to spend " + (parseFloat(blockPrice) / (10 ** 10)) + " RMRK to buy this land block"}
                         popupButtonMessage="Approve"
-                        popupButtonAction={approveXCRMRK(blockPrice)} />
+                        popupButtonAction={approveXCRMRK} />
                     :
                     <></>
                 }
@@ -232,14 +232,21 @@ function OfferCard(props) {
                                 Cancel
                             </Button>
                         </Box> :
-                        <Box display='flex'>
-                            <Button onClick={setPopupApproveBuy} className='yellowButton' variant='contained' sx={{ mt: 2, fontWeight: 'bold', color: '#282c34', width: 100 }}>
-                                Approve buy
-                            </Button>
-                            <Button onClick={setPopupBuyOffer} className='yellowButton' variant='contained' sx={{ mt: 2, fontWeight: 'bold', color: '#282c34', width: 100 }}>
-                                Buy
-                            </Button>
-                        </Box>
+
+
+                        <Grid container direction='column' spacing={1} justifyContent='center'>
+                            <Grid item xs='auto'>
+                                <Button onClick={setPopupApproveBuy} className='yellowButton' variant='contained' size='small' sx={{ mt: 2, fontWeight: 'bold', color: '#282c34', width: 100 }} noWrap>
+                                    Approve purchase
+                                </Button>
+                            </Grid>
+
+                            <Grid item xs='auto'>
+                                <Button onClick={setPopupBuyOffer} className='yellowButton' variant='contained' size='small' sx={{ fontWeight: 'bold', color: '#282c34', width: 100 }}>
+                                    Buy
+                                </Button>
+                            </Grid>
+                        </Grid>
                     }
                 </Box>
             </CardActions>


### PR DESCRIPTION
Fixed errors:
- OfferCard popups now show correctly and don't launch functions before opening;
- Adding (NaN, NaN) lands to the list in the "Create new offer" section is not possible anymore: initialization of X and Y values was incorrect, now it reports the right error log;
- For the same reason, "RMRK amount" input has been initialized as NaN: it should prevent the creation of "free" offers even if the user does not change the price before doing the other steps.

Small tweaks:
- Fixed size and position of buttons in OfferCard;
- Fixes size of TextField components in CreateOffer section.